### PR TITLE
Fixed problem with default value for prometheus.io/scrape annotation

### DIFF
--- a/auto-deploy-aspnetcore/values.yaml
+++ b/auto-deploy-aspnetcore/values.yaml
@@ -37,4 +37,4 @@ resources:
     cpu: 300m
     memory: 1Gi
 podAnnotations:
-  prometheus.io/scrape: "\"true\""
+  prometheus.io/scrape: "true"


### PR DESCRIPTION
The value should be a boolean, not string.